### PR TITLE
Use casecmp_to when comparing song metadata

### DIFF
--- a/Steno Hero/Scripts/SongMetaDataProvider.gd
+++ b/Steno Hero/Scripts/SongMetaDataProvider.gd
@@ -149,11 +149,11 @@ class MetaDataComparer:
 				return false;
 		
 		if(a.artist != null && b.artist != null && a.artist != b.artist):
-			return a.artist.nocasecmp_to(b.artist);
+			return a.artist.casecmp_to(b.artist);
 		
 		if(!b.title):
 			return true;
 		if(!a.title):
 			return false;
 			
-		return a.title.nocasecmp_to(b.title) < 0;
+		return a.title.casecmp_to(b.title) < 0;


### PR DESCRIPTION
For some reason, in the presence of custom .lrc files in the Songs directory, the call to nocasecmp_to sometimes segfaults.

I suggest using casecmp_to as a workaround, since it doesn't seem to segfault, and the results should be the same as a case-insensitive comparison.